### PR TITLE
Fix `setbytes` raising TypeError since fs 2.0.12`

### DIFF
--- a/webdavfs/webdavfs.py
+++ b/webdavfs/webdavfs.py
@@ -306,7 +306,7 @@ class WebDAVFS(FS):
 
     def setbytes(self, path, contents):
         if not isinstance(contents, bytes):
-            raise ValueError('contents must be bytes')
+            raise TypeError('contents must be bytes')
         _path = self.validatepath(path)
         bin_file = io.BytesIO(contents)
         with self._lock:


### PR DESCRIPTION
@zopyx : since Will released fs `v2.0.12`, `FS.setbytes` is expected to raise `TypeError` on bad input.