### PR TITLE
Fix `openbin` not raising `ResourceNotFound` on missing parent

### DIFF
--- a/webdavfs/webdavfs.py
+++ b/webdavfs/webdavfs.py
@@ -19,6 +19,7 @@ from fs.enums import ResourceType, Seek
 from fs.info import Info
 from fs.iotools import line_iterator
 from fs.mode import Mode
+from fs.path import dirname
 
 
 log = logging.getLogger(__name__)
@@ -294,6 +295,9 @@ class WebDAVFS(FS):
             except errors.ResourceNotFound:
                 if not _mode.create:
                     raise errors.ResourceNotFound(path)
+                # Check the parent is an existing directory
+                if self.gettype(dirname(_path)) is not ResourceType.directory:
+                    raise errors.DirectoryExpected(dirname(path))
             else:
                 if info.is_dir:
                     raise errors.FileExpected(path)


### PR DESCRIPTION
This should fix the failing tests on Travis-CI.

BTW, you should consider using another test runner for the CI, as the logs are very hard to read because of the extremely verbose output. I'd recommend using `green`, which is compatible with `unittest` formatted tests, and produces better output, while also supressing standard output completely from successful test cases. See [here](https://travis-ci.org/althonos/fs.archive/jobs/365621586) for a successful example, and [here](https://travis-ci.org/althonos/fs.archive/jobs/285233087) for what is reported when a test case fails. If you want, I can provide another PR with appropriate configuration.