### PR TITLE
Avoid loading entire file in memory

### DIFF
--- a/webdavfs/webdavfs.py
+++ b/webdavfs/webdavfs.py
@@ -6,7 +6,6 @@ import datetime
 import dateutil.parser
 import dateutil.tz
 import threading
-import operator
 import logging
 
 import webdav3.client as wc


### PR DESCRIPTION
When opening a remote file, the `WebDAVFile` instance holds the entire file in memory in the `data` variable, this works fine for relatively small files but can cause severe memory bottleneck issues with bigger files depending on your use case.

This PR adds an option to write the remote file to a temporary local file instead. To use this alternative mode pass `use_temp_files=True` when creating your `WebDAVFS`. You can also optionally set the directory where the temporary files will be created or leave it as None to use the default system's temp directory.
```python
WebDAVFS(url, login=login, password=password, root=root, use_temp_files=True, temp_path="/your/temp/path")
```

Here is a memory profile output using both modes for a remote file of about 12MB:

### With the default in-memory file
```
Done reading 12846507 bytes in 1570 chunks


Filename: script/test.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    20     34.5 MiB     34.5 MiB           1   @profile
    21                                         def test_webdav_open_file():
    22     34.5 MiB      0.0 MiB           1       use_temp_files=False
    23                                             
    24     34.5 MiB      0.0 MiB           1       with WebDAVFS(url, login=login, password=password, root=root, use_temp_files=use_temp_files, temp_path=temp_path) as handle:
    25                                                 # List resources in the root directory
    26     37.6 MiB      3.0 MiB           1           list_resouces(handle)
    27                                         
    28     37.6 MiB      0.0 MiB           1           total_size = handle.getsize(remote_filename)
    29     37.6 MiB      0.0 MiB           1           total_chunks_read = 0
    30                                         
    31                                                 # Open the remote file
    32     50.7 MiB     13.1 MiB           1           with handle.open(remote_filename, 'rb') as file:
    33                                         
    34     50.7 MiB      0.0 MiB           1               chunk_size = 8192
    35     50.7 MiB      0.0 MiB           1               while True:
    36     50.7 MiB      0.0 MiB        1570                   chunk = file.read(chunk_size)
    37     50.7 MiB      0.0 MiB        1570                   total_chunks_read += 1
    38     50.7 MiB      0.0 MiB        1570                   if not chunk:
    39     38.5 MiB    -12.1 MiB           1                       break
    40                                         
    41     38.5 MiB      0.0 MiB           1           print(f'\n\nDone reading {total_size} bytes in {total_chunks_read} chunks\n\n')
```

### With `use_temp_files=True`
```
Done reading 12846507 bytes in 1570 chunks


Filename: script/test.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    20     34.5 MiB     34.5 MiB           1   @profile
    21                                         def test_webdav_open_file():
    22     34.5 MiB      0.0 MiB           1       use_temp_files=True
    23                                             
    24     34.5 MiB      0.0 MiB           1       with WebDAVFS(url, login=login, password=password, root=root, use_temp_files=use_temp_files, temp_path=temp_path) as handle:
    25                                                 # List resources in the root directory
    26     37.6 MiB      3.0 MiB           1           list_resouces(handle)
    27                                         
    28     37.6 MiB      0.0 MiB           1           total_size = handle.getsize(remote_filename)
    29     37.6 MiB      0.0 MiB           1           total_chunks_read = 0
    30                                         
    31                                                 # Open the remote file
    32     38.5 MiB      0.9 MiB           1           with handle.open(remote_filename, 'rb') as file:
    33                                         
    34     38.5 MiB      0.0 MiB           1               chunk_size = 8192
    35     38.5 MiB      0.0 MiB           1               while True:
    36     38.5 MiB      0.0 MiB        1570                   chunk = file.read(chunk_size)
    37     38.5 MiB      0.0 MiB        1570                   total_chunks_read += 1
    38     38.5 MiB      0.0 MiB        1570                   if not chunk:
    39     38.5 MiB      0.0 MiB           1                       break
    40                                         
    41     38.5 MiB      0.0 MiB           1           print(f'\n\nDone reading {total_size} bytes in {total_chunks_read} chunks\n\n')
```
The main difference can be observed in line 32.

This should address #32